### PR TITLE
Add SSL capability

### DIFF
--- a/Network/Docker/Types.hs
+++ b/Network/Docker/Types.hs
@@ -40,8 +40,8 @@ data DockerClientOpts = DockerClientOpts {
 
 
 data SSLOptions = SSLOptions {
-    optionsClientCert :: FilePath
-  , optionsCaCert     :: FilePath 
+    optionsKey  :: FilePath
+  , optionsCert :: FilePath 
   } deriving Show
 
 

--- a/Network/Docker/Types.hs
+++ b/Network/Docker/Types.hs
@@ -20,7 +20,7 @@ import qualified Data.Text              as T
 import           GHC.Generics
 import           Network.Docker.Options
 import           Network.Wreq.Types     (Postable)
-
+import           OpenSSL.Session        (SSLContext)
 
 type URL = String
 type ApiVersion = String
@@ -31,10 +31,19 @@ type IP = String
 type Port = Int
 type PortType = String
 
+data SSL = NoSSL | SSL SSLOptions deriving Show
+
 data DockerClientOpts = DockerClientOpts {
       apiVersion :: ApiVersion
     , baseUrl    :: URL
+    , ssl        :: SSL
     } deriving (Show)
+
+
+data SSLOptions = SSLOptions {
+    optionsClientCert :: FilePath
+  , optionsCaCert     :: FilePath 
+  } deriving Show
 
 
 data ResourceId = ResourceId { _id :: String } deriving (Show, Eq)

--- a/Network/Docker/Types.hs
+++ b/Network/Docker/Types.hs
@@ -9,7 +9,6 @@ module Network.Docker.Types where
 import           Prelude                hiding(id)
 import           Control.Applicative
 import           Control.Lens.TH
-import           Control.Lens.TH
 import           Data.Aeson
 import           Data.Aeson.TH
 import           Data.Bool

--- a/docker.cabal
+++ b/docker.cabal
@@ -35,6 +35,8 @@ library
                      , pipes >= 4.1.2
                      , pipes-text >= 0.0.0.12
                      , pipes-bytestring >= 2.1.0
+                     , HsOpenSSL
+                     , http-client-openssl
   -- hs-source-dirs:
   default-language:    Haskell2010
 
@@ -59,6 +61,8 @@ test-suite tests
                        , tasty-hunit >= 0.8
                        , process
                        , http-types
+                       , HsOpenSSL
+                       , http-client-openssl
     type:                exitcode-stdio-1.0
     main-is:             tests.hs
     hs-source-dirs:      tests


### PR DESCRIPTION
Some docker installations require SSL connection to docker daemon. (e.g. using docker-machine)
This PR adds sufficient capabilities. 