### PR TITLE
Makes `oomKillDisable` in `ContainerResources` optional.

### DIFF
--- a/docker.cabal
+++ b/docker.cabal
@@ -1,5 +1,5 @@
 name:                docker
-version:             0.4.0.0
+version:             0.4.0.1
 synopsis:            An API client for docker written in Haskell
 description:         See API documentation below.
 homepage:            https://github.com/denibertovic/docker-hs

--- a/src/Docker/Client/Types.hs
+++ b/src/Docker/Client/Types.hs
@@ -698,7 +698,7 @@ defaultContainerResources = ContainerResources {
                         , memory=Nothing
                         , memoryReservation=Nothing
                         , memorySwap=Nothing
-                        , oomKillDisable=False
+                        , oomKillDisable=Just False
                         , ulimits=[]
                         }
 
@@ -1310,7 +1310,7 @@ data ContainerResources = ContainerResources {
                         , memoryReservation    :: Maybe MemoryConstraint
                         , memorySwap           :: Maybe MemoryConstraint
                         -- , memorySwappiness  :: Integer -- 1.24: Missing from inspecting container details... Going to omit for now.
-                        , oomKillDisable       :: Bool
+                        , oomKillDisable       :: Maybe Bool
                         -- , pidsLimit         :: Integer -- 1.24: Missing from inspecting container details... Going to omit for now.
                         , ulimits              :: [Ulimit]
                         -- TODO: Missing from 1.24


### PR DESCRIPTION
Fixes #31