### PR TITLE
added contribution guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,14 @@
-# TODO
+# Contributing
 
-Add basic guidelines here, things like style guide (using .configuration files from the repo) etc etc.
+If you wish to contribute please see [any issue on GitHub tagged with "help
+wanted"](https://github.com/denibertovic/docker-hs/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+Before starting to work, consider commenting on the issue you want to resolve or
+open a new issue to discuss design decisions and implementation details. This is
+so that no development cycles go to waste on implementing a feature that might
+not get merged either because of implementation details or other reasons.
 
+Make sure to submit your PR's against the `master` branch.
+
+## Project Setup
+
+See the `README.md` file on how to setup the project on your development machine.

--- a/README.md
+++ b/README.md
@@ -14,16 +14,17 @@ Older docker version and engine api versions are not supported at the moment.
 
 ## Contributing
 
-If you wish to contribute please see any issue tagged with "help wanted".
-Make sure to submit your PR's against the `master` branch.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Please consider filling an Issue first and discuss design decisions and implementation details before
-writing any code. This is so that no development cycles go to waste on implementing a feature that
-might not get merged either because of implementation details or other reasons.
+### Project Setup
 
+For working on the library, you need the Haskell Tool Stack installed (see [the
+Haskell Tool Stack
+website](https://docs.haskellstack.org/en/stable/install_and_upgrade/)). You
+also need `make` to use the `Makefile` included in the project. Run `make help`
+to see the available commands (for building, running the tests and releasing).
 
 ## IRC
 
 If you have any questions or suggestions you can find the maintainers in `#docker-haskell`
 on freenode.
-


### PR DESCRIPTION
This fixes #37 

This is a first draft for the contribution guidelines. Considering the size of the project, this should be nearly enough. For a very detailed example see https://github.com/WeAllJS/weallcontribute/blob/latest/CONTRIBUTING.md

I feel that the "Project Setup" part should also reside in `CONTRIBUTING.md` and only be referenced from `README.md`.