### PR TITLE
Fix EnvVar JSON encoding

### DIFF
--- a/src/Docker/Client/Types.hs
+++ b/src/Docker/Client/Types.hs
@@ -1348,7 +1348,7 @@ instance FromJSON EnvVar where
     parseJSON _ = fail "EnvVar is not a string"
 
 instance ToJSON EnvVar where
-    toJSON (EnvVar n v) = object [n .= v]
+    toJSON (EnvVar n v) = JSON.String $ n <> T.pack "=" <> v
 
 -- | ExposedPort represents a port (and it's type)
 -- that a container should expose to other containers or the host system.

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -163,6 +163,15 @@ testEntrypointJson = testGroup "Testing ContainerConfig JSON" [testSample1, test
       Just (Entrypoint sampleEntrypointArr)
     sampleEntrypointArr = ["cmd", "--some-flag", "--some-flag2"]
 
+testEnvVarJson :: TestTree
+testEnvVarJson = testGroup "Testing EnvVar JSON" [testSampleEncode, testSampleDecode]
+  where
+    testSampleEncode =
+      testCase "Test toJSON" $ assert $ JSON.toJSON (EnvVar "cellar" "door") == JSON.String "cellar=door"
+    testSampleDecode =
+      testCase "Test fromJSON" $ assert $ (JSON.decode "\"cellar=door\"" :: Maybe EnvVar) ==
+        Just (EnvVar "cellar" "door")
+
 integrationTests :: TestTree
 integrationTests =
   testGroup
@@ -183,6 +192,7 @@ jsonTests =
     , testLabelsJson
     , testLogDriverOptionsJson
     , testEntrypointJson
+    , testEnvVarJson
     ]
 
 setup :: IO ()


### PR DESCRIPTION
`EnvVar`s are encoded as `name=value` strings (see example 
 here: https://docs.docker.com/engine/api/v1.24/#31-containers). 
`FromJSON` instance already follows this format, this PR fixes `ToJSON`.
  