### PR TITLE
Bump versions for http-conduit and http-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.0.2 (2018-02-21)
 
 - Support http-conduit-2.3.0.
+- Bump http-types versions.
 
 ## 0.5.0.1 (2018-01-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.0.2 (2018-02-21)
+
+- Support http-conduit-2.3.0.
+
 ## 0.5.0.1 (2018-01-26)
 
 - Bumps upper bound for http-types (properly this time).

--- a/docker.cabal
+++ b/docker.cabal
@@ -1,5 +1,5 @@
 name:                docker
-version:             0.5.0.1
+version:             0.5.0.2
 synopsis:            An API client for docker written in Haskell
 description:         See API documentation below.
 homepage:            https://github.com/denibertovic/docker-hs
@@ -14,6 +14,13 @@ extra-source-files:  README.md
 cabal-version:       >=1.10
 stability:           experimental
 
+Flag small-http-conduit
+    Description: Resolve whether http-conduit < 2.3.0.
+    Manual: False
+    Default: True
+
+-- build-depends:   unliftio-core
+-- # http-conduit >= 2.3.0
 library
   default-extensions:          DeriveGeneric, OverloadedStrings, ScopedTypeVariables, ExplicitForAll, MultiParamTypeClasses, FlexibleContexts, GeneralizedNewtypeDeriving, RankNTypes, DeriveFunctor, FlexibleInstances, CPP
   hs-source-dirs:      src
@@ -54,6 +61,11 @@ library
                      , x509 >= 1.6.0 && < 1.8.0
                      , x509-store >= 1.6.0 && < 1.8.0
                      , x509-system >= 1.6.0 && < 1.8.0
+  if flag(small-http-conduit)
+      build-depends: http-conduit < 2.3.0
+  else
+      build-depends: http-conduit >= 2.3.0
+                   , unliftio-core
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing
 

--- a/docker.cabal
+++ b/docker.cabal
@@ -19,8 +19,6 @@ stability:           experimental
 --     Manual: False
 --     Default: True
 
--- build-depends:   unliftio-core
--- # http-conduit >= 2.3.0
 library
   default-extensions:          DeriveGeneric, OverloadedStrings, ScopedTypeVariables, ExplicitForAll, MultiParamTypeClasses, FlexibleContexts, GeneralizedNewtypeDeriving, RankNTypes, DeriveFunctor, FlexibleInstances, CPP
   hs-source-dirs:      src
@@ -33,13 +31,12 @@ library
                      , containers >= 0.5.0 && < 0.6.0
                      , data-default-class >= 0.0.1 && < 0.2.0
                      , http-client >= 0.4.0 && < 0.6.0
-                     , http-types >= 0.9 && < 0.12
+                     , http-types >= 0.9 && < 0.13
                      , vector
                      , conduit
                      , conduit-combinators
                      , conduit-extra
                      , exceptions
-                     , http-conduit
                      , monad-control
                      , resourcet
                      , transformers

--- a/docker.cabal
+++ b/docker.cabal
@@ -14,10 +14,10 @@ extra-source-files:  README.md
 cabal-version:       >=1.10
 stability:           experimental
 
-Flag small-http-conduit
-    Description: Resolve whether http-conduit < 2.3.0.
-    Manual: False
-    Default: True
+-- Flag small-http-conduit
+--     Description: Resolve whether http-conduit < 2.3.0.
+--     Manual: False
+--     Default: True
 
 -- build-depends:   unliftio-core
 -- # http-conduit >= 2.3.0
@@ -61,11 +61,13 @@ library
                      , x509 >= 1.6.0 && < 1.8.0
                      , x509-store >= 1.6.0 && < 1.8.0
                      , x509-system >= 1.6.0 && < 1.8.0
-  if flag(small-http-conduit)
-      build-depends: http-conduit < 2.3.0
-  else
-      build-depends: http-conduit >= 2.3.0
-                   , unliftio-core
+                     , http-conduit
+                     , unliftio-core
+  -- if flag(small-http-conduit)
+  --     build-depends: http-conduit < 2.3.0
+  -- else
+  --     build-depends: http-conduit >= 2.3.0
+  --                  , unliftio-core
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing
 


### PR DESCRIPTION
Should fix fpco/stackage#3232, fpco/stackage#3204, and (mostly) #54. @denibertovic, can you release assuming tests pass? 