### PR TITLE
Implement network alias configuration via NetworkingConfig

### DIFF
--- a/src/Docker/Client/Types.hs
+++ b/src/Docker/Client/Types.hs
@@ -624,9 +624,12 @@ instance ToJSON EndpointConfig where
     [ "Aliases" .= aliases
     ]
 
+-- | Alias for endpoint name
+type EndpointName = Text
+
 -- | Data type for the NetworkingConfig section of the container settings
 newtype NetworkingConfig = NetworkingConfig
-  { endpointsConfig :: HM.HashMap Text EndpointConfig
+  { endpointsConfig :: HM.HashMap EndpointName EndpointConfig
   } deriving (Eq, Show)
 
 instance ToJSON NetworkingConfig where
@@ -636,9 +639,9 @@ instance ToJSON NetworkingConfig where
 
 -- | Options used for creating a Container.
 data CreateOpts = CreateOpts {
-                  containerConfig :: ContainerConfig
-                , hostConfig      :: HostConfig
-                , networkingConfig   :: Maybe NetworkingConfig
+                  containerConfig  :: ContainerConfig
+                , hostConfig       :: HostConfig
+                , networkingConfig :: NetworkingConfig
                 } deriving (Eq, Show)
 
 instance ToJSON CreateOpts where
@@ -648,9 +651,7 @@ instance ToJSON CreateOpts where
         case ccJSON of
             JSON.Object (o :: HM.HashMap T.Text JSON.Value) -> do
                 let o1 = HM.insert "HostConfig" hcJSON o
-                let o2 = case nc of
-                           Nothing -> o1
-                           Just _  -> HM.insert "NetworkingConfig" (toJSON nc) o1
+                let o2 = HM.insert "NetworkingConfig" (toJSON nc) o1
                 JSON.Object o2
             _ -> error "ContainerConfig is not an object." -- This should never happen.
 
@@ -736,7 +737,7 @@ defaultCreateOpts :: T.Text -> CreateOpts
 defaultCreateOpts imageName = CreateOpts
   { containerConfig  = defaultContainerConfig imageName
   , hostConfig       = defaultHostConfig
-  , networkingConfig = Nothing
+  , networkingConfig = NetworkingConfig HM.empty
   }
 
 -- | Override the key sequence for detaching a container.

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -14,6 +14,7 @@ import           Control.Monad             (forM_)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class (lift)
 import qualified Data.Aeson                as JSON
+import           Data.Aeson                ((.=))
 import           Data.Aeson.Lens           (key, _Array, _Null, _Object,
                                             _String, _Value)
 import qualified Data.ByteString           as B
@@ -92,7 +93,7 @@ testRunAndReadLog :: IO ()
 testRunAndReadLog =
   runDocker $
   do let containerConfig = (defaultContainerConfig (testImageName <> ":latest")) {env = [EnvVar "TEST" "123"]}
-     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig) Nothing
+     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig Nothing) Nothing
      c <- fromRight containerId
      status1 <- startContainer defaultStartOpts c
      _ <- inspectContainer c >>= fromRight
@@ -184,6 +185,20 @@ testEnvVarJson = testGroup "Testing EnvVar JSON" [testSampleEncode, testSampleDe
       testCase "Test fromJSON" $ assert $ (JSON.decode "\"cellar=door\"" :: Maybe EnvVar) ==
         Just (EnvVar "cellar" "door")
 
+testNetworkingConfigJson :: TestTree
+testNetworkingConfigJson = testGroup "Testing NetworkingConfig JSON" [testSampleEncode]
+  where
+    testSampleEncode =
+      let networkingConfig = NetworkingConfig $ HM.fromList [("custom-network", EndpointConfig ["cellar", "door"])]
+       in testCase "Test toJSON" $ assert $ JSON.toJSON networkingConfig ==
+        JSON.object
+          [ "EndpointsConfig" .= JSON.object
+            [ "custom-network" .= JSON.object
+              [ "Aliases" .= (["cellar", "door"] :: [Text])
+              ]
+            ]
+          ]
+
 integrationTests :: TestTree
 integrationTests =
   testGroup
@@ -206,6 +221,7 @@ jsonTests =
     , testLogDriverOptionsJson
     , testEntrypointJson
     , testEnvVarJson
+    , testNetworkingConfigJson
     ]
 
 setup :: IO ()

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -93,7 +93,8 @@ testRunAndReadLog :: IO ()
 testRunAndReadLog =
   runDocker $
   do let containerConfig = (defaultContainerConfig (testImageName <> ":latest")) {env = [EnvVar "TEST" "123"]}
-     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig Nothing) Nothing
+         networkingConfig = NetworkingConfig $ HM.fromList [("test-network", EndpointConfig ["cellar-door"])]
+     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig (Just networkingConfig)) Nothing
      c <- fromRight containerId
      status1 <- startContainer defaultStartOpts c
      _ <- inspectContainer c >>= fromRight

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -94,7 +94,7 @@ testRunAndReadLog =
   runDocker $
   do let containerConfig = (defaultContainerConfig (testImageName <> ":latest")) {env = [EnvVar "TEST" "123"]}
          networkingConfig = NetworkingConfig $ HM.fromList [("test-network", EndpointConfig ["cellar-door"])]
-     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig (Just networkingConfig)) Nothing
+     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig networkingConfig) Nothing
      c <- fromRight containerId
      status1 <- startContainer defaultStartOpts c
      _ <- inspectContainer c >>= fromRight


### PR DESCRIPTION
This PR makes it possible to set network aliases for containers (a Docker feature used by docker-compose, for example). A new optional (not included by default) section, `NetworkingConfig` is added to the container `CreateOpts`. 

As features in the `EndpointsConfig`are in general not very well-documented (at least for v1.24 of the API) aliases are the only feature added from this section.

An JSON example, see "Create a container" in the [Docker API documentation](https://docs.docker.com/engine/api/v1.24/).
```js
"NetworkingConfig": {
    "EndpointsConfig": {
        "isolated_nw": {
            "Aliases": [
                "server_x",
                "server_y"
            ]
        }
    }
}
```

The feature was tested manually and a unit test for encoding JSON has been added too.

Looking forward to your feedback.