### PR TITLE
Implement create/remove network API and fix PRs #57 and #59

### DIFF
--- a/src/Docker/Client/Api.hs
+++ b/src/Docker/Client/Api.hs
@@ -20,6 +20,9 @@ module Docker.Client.Api (
     , listImages
     , buildImageFromDockerfile
     , pullImage
+    -- * Network
+    , createNetwork
+    , removeNetwork
     -- * Other
     , getDockerVersion
     ) where
@@ -206,4 +209,12 @@ buildImageFromDockerfile opts base = do
 -- the image from a tarball or a URL.
 pullImage :: forall m b . (MonadIO m, MonadMask m) => T.Text -> Tag -> Sink BS.ByteString m b -> DockerT m (Either DockerError b)
 pullImage name tag = requestHelper' POST (CreateImageEndpoint name tag Nothing)
+
+-- | Creates network
+createNetwork :: forall m. (MonadIO m, MonadMask m) => CreateNetworkOpts -> DockerT m (Either DockerError NetworkID)
+createNetwork opts = requestHelper POST (CreateNetworkEndpoint opts)  >>= parseResponse
+
+-- | Removes a network
+removeNetwork :: forall m. (MonadIO m, MonadMask m) => NetworkID -> DockerT m (Either DockerError ())
+removeNetwork nid = requestUnit DELETE $ RemoveNetworkEndpoint nid
 

--- a/src/Docker/Client/Http.hs
+++ b/src/Docker/Client/Http.hs
@@ -273,4 +273,14 @@ statusCodeToError (CreateImageEndpoint _ _ _) st =
         Nothing
     else
         Just $ DockerInvalidStatusCode st
+statusCodeToError (CreateNetworkEndpoint _) st =
+    if st == status201 then
+        Nothing
+    else
+        Just $ DockerInvalidStatusCode st
+statusCodeToError (RemoveNetworkEndpoint _) st =
+    if st == status204 then
+        Nothing
+    else
+        Just $ DockerInvalidStatusCode st
 

--- a/src/Docker/Client/Internal.hs
+++ b/src/Docker/Client/Internal.hs
@@ -75,6 +75,8 @@ getEndpoint v (CreateImageEndpoint name tag _) = encodeURLWithQuery [v, "images"
         where query = [("fromImage", Just n), ("tag", Just t)]
               n = encodeQ $ T.unpack name
               t = encodeQ $ T.unpack tag
+getEndpoint v (CreateNetworkEndpoint _) = encodeURL [v, "networks", "create"]
+getEndpoint v (RemoveNetworkEndpoint nid) = encodeURL [v, "networks", fromNetworkID nid]
 
 getEndpointRequestBody :: Endpoint -> Maybe HTTP.RequestBody
 getEndpointRequestBody VersionEndpoint = Nothing
@@ -94,6 +96,8 @@ getEndpointRequestBody (InspectContainerEndpoint _) = Nothing
 
 getEndpointRequestBody (BuildImageEndpoint _ fp) = Just $ requestBodySourceChunked $ CB.sourceFile fp
 getEndpointRequestBody (CreateImageEndpoint _ _ _) = Nothing
+getEndpointRequestBody (CreateNetworkEndpoint opts) = Just $ HTTP.RequestBodyLBS (JSON.encode opts)
+getEndpointRequestBody (RemoveNetworkEndpoint _) = Nothing
 
 getEndpointContentType :: Endpoint -> BSC.ByteString
 getEndpointContentType (BuildImageEndpoint _ _) = BSC.pack "application/tar"

--- a/src/Docker/Client/Types.hs
+++ b/src/Docker/Client/Types.hs
@@ -624,9 +624,12 @@ instance ToJSON EndpointConfig where
     [ "Aliases" .= aliases
     ]
 
+-- | Alias for endpoint name
+type EndpointName = Text
+
 -- | Data type for the NetworkingConfig section of the container settings
 newtype NetworkingConfig = NetworkingConfig
-  { endpointsConfig :: HM.HashMap Text EndpointConfig
+  { endpointsConfig :: HM.HashMap EndpointName EndpointConfig
   } deriving (Eq, Show)
 
 instance ToJSON NetworkingConfig where
@@ -636,9 +639,9 @@ instance ToJSON NetworkingConfig where
 
 -- | Options used for creating a Container.
 data CreateOpts = CreateOpts {
-                  containerConfig :: ContainerConfig
-                , hostConfig      :: HostConfig
-                , networkingConfig   :: Maybe NetworkingConfig
+                  containerConfig  :: ContainerConfig
+                , hostConfig       :: HostConfig
+                , networkingConfig :: NetworkingConfig
                 } deriving (Eq, Show)
 
 instance ToJSON CreateOpts where
@@ -648,9 +651,7 @@ instance ToJSON CreateOpts where
         case ccJSON of
             JSON.Object (o :: HM.HashMap T.Text JSON.Value) -> do
                 let o1 = HM.insert "HostConfig" hcJSON o
-                let o2 = case nc of
-                           Nothing -> o1
-                           Just _  -> HM.insert "NetworkingConfig" (toJSON nc) o1
+                let o2 = HM.insert "NetworkingConfig" (toJSON nc) o1
                 JSON.Object o2
             _ -> error "ContainerConfig is not an object." -- This should never happen.
 
@@ -736,7 +737,7 @@ defaultCreateOpts :: T.Text -> CreateOpts
 defaultCreateOpts imageName = CreateOpts
   { containerConfig  = defaultContainerConfig imageName
   , hostConfig       = defaultHostConfig
-  , networkingConfig = Nothing
+  , networkingConfig = NetworkingConfig HM.empty
   }
 
 -- | Override the key sequence for detaching a container.

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -114,6 +114,15 @@ testRunAndReadLogHelper networkingConfig =
     isRightUnit (Right ()) = True
     isRightUnit _          = False
 
+testCreateRemoveNetwork :: IO ()
+testCreateRemoveNetwork = do
+  runDocker $ do
+    createStatus <- createNetwork $ defaultCreateNetworkOpts "test-network"
+    lift $ assertBool ("creating a network, unexpected status: " ++ show createStatus) $ isRight createStatus
+    nid <- fromRight createStatus
+    removeStatus <- removeNetwork nid
+    lift $ assertBool ("removing a network, unexpected status: " ++ show removeStatus) $ isRight removeStatus
+
 testLogDriverOptionsJson :: TestTree
 testLogDriverOptionsJson = testGroup "Testing LogDriverOptions JSON" [test1, test2, test3]
   where
@@ -217,6 +226,7 @@ integrationTests =
     , testCase "Run a dummy container and read its log" testRunAndReadLog
     , testCase "Run a dummy container with networking and read its log" testRunAndReadLogWithNetworking
     , testCase "Try to stop a container that doesn't exist" testStopNonexisting
+    , testCase "Create and remove a network" testCreateRemoveNetwork
     ]
 
 jsonTests :: TestTree

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -14,6 +14,7 @@ import           Control.Monad             (forM_)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class (lift)
 import qualified Data.Aeson                as JSON
+import           Data.Aeson                ((.=))
 import           Data.Aeson.Lens           (key, _Array, _Null, _Object,
                                             _String, _Value)
 import qualified Data.ByteString           as B
@@ -92,7 +93,7 @@ testRunAndReadLog :: IO ()
 testRunAndReadLog =
   runDocker $
   do let containerConfig = (defaultContainerConfig (testImageName <> ":latest")) {env = [EnvVar "TEST" "123"]}
-     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig) Nothing
+     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig Nothing) Nothing
      c <- fromRight containerId
      status1 <- startContainer defaultStartOpts c
      _ <- inspectContainer c >>= fromRight
@@ -184,6 +185,20 @@ testEnvVarJson = testGroup "Testing EnvVar JSON" [testSampleEncode, testSampleDe
       testCase "Test fromJSON" $ assert $ (JSON.decode "\"cellar=door\"" :: Maybe EnvVar) ==
         Just (EnvVar "cellar" "door")
 
+testNetworkingConfigJson :: TestTree
+testNetworkingConfigJson = testGroup "Testing NetworkingConfig JSON" [testSampleEncode]
+  where
+    testSampleEncode =
+      let networkingConfig = NetworkingConfig $ HM.fromList [("custom-network", EndpointConfig ["cellar", "door"])]
+       in testCase "Test toJSON" $ assert $ JSON.toJSON networkingConfig ==
+        JSON.object
+          [ "EndpointsConfig" .= JSON.object
+            [ "custom-network" .= JSON.object
+              [ "Aliases" .= (["cellar", "door"] :: [Text])
+              ]
+            ]
+          ]
+
 integrationTests :: TestTree
 integrationTests =
   testGroup
@@ -206,6 +221,7 @@ jsonTests =
     , testLogDriverOptionsJson
     , testEntrypointJson
     , testEnvVarJson
+    , testNetworkingConfigJson
     ]
 
 setup :: IO ()

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -93,7 +93,8 @@ testRunAndReadLog :: IO ()
 testRunAndReadLog =
   runDocker $
   do let containerConfig = (defaultContainerConfig (testImageName <> ":latest")) {env = [EnvVar "TEST" "123"]}
-     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig Nothing) Nothing
+         networkingConfig = NetworkingConfig $ HM.fromList [("test-network", EndpointConfig ["cellar-door"])]
+     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig (Just networkingConfig)) Nothing
      c <- fromRight containerId
      status1 <- startContainer defaultStartOpts c
      _ <- inspectContainer c >>= fromRight

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -94,7 +94,7 @@ testRunAndReadLog =
   runDocker $
   do let containerConfig = (defaultContainerConfig (testImageName <> ":latest")) {env = [EnvVar "TEST" "123"]}
          networkingConfig = NetworkingConfig $ HM.fromList [("test-network", EndpointConfig ["cellar-door"])]
-     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig (Just networkingConfig)) Nothing
+     containerId <- createContainer (CreateOpts containerConfig defaultHostConfig networkingConfig) Nothing
      c <- fromRight containerId
      status1 <- startContainer defaultStartOpts c
      _ <- inspectContainer c >>= fromRight


### PR DESCRIPTION
This PR is based on top of these two PRs
https://github.com/denibertovic/docker-hs/pull/57
https://github.com/denibertovic/docker-hs/pull/59

I found out that the reason for tests failing on Travis CI was that they were assuming network named "test-network" to exist, which is not the case on Travis CI.

I've fixed that by adding APIs for creating/removing networks and then using them to ensure that "test-network" exist.