### PR TITLE
bump containers bound; build against ghc 8.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ env:
     - DOCKER_VERSION="1.13.1-0~ubuntu-trusty"       GHCVER=8.0.2
     - DOCKER_VERSION="17.05.0~ce-0~ubuntu-trusty"   GHCVER=8.0.2
 
+    - DOCKER_VERSION="1.12.3-0~trusty"              GHCVER=8.6.4
+    - DOCKER_VERSION="1.13.1-0~ubuntu-trusty"       GHCVER=8.6.4
+    - DOCKER_VERSION="17.05.0~ce-0~ubuntu-trusty"   GHCVER=8.6.4
+
 addons:
   apt:
     packages:

--- a/docker.cabal
+++ b/docker.cabal
@@ -28,7 +28,7 @@ library
                      , aeson >= 0.9.0 && < 2.0.0
                      , blaze-builder >= 0.4.0 && < 0.5.0
                      , bytestring >= 0.10.0 && < 0.11.0
-                     , containers >= 0.5.0 && < 0.6.0
+                     , containers >= 0.5.0 && < 0.7.0
                      , data-default-class >= 0.0.1 && < 0.2.0
                      , http-client >= 0.4.0 && < 0.6.0
                      , http-types >= 0.9 && < 0.13

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -1,0 +1,4 @@
+resolver: lts-13.19
+packages:
+- '.'
+extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.0.2.yaml
+stack-8.6.4.yaml

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -76,7 +76,7 @@ testFindImage =
 
 testDeleteImage :: IO ()
 testDeleteImage = runDocker $ do
-  (Just img) <- findTestImage
+  img <- fmap fromJust findTestImage
   result <- deleteImage defaultImageDeleteOpts (imageId img)
   lift $ assert $ isRight result
   maybeTestImageAfter <- findTestImage


### PR DESCRIPTION
`containers` has been bumped to `0.6.0.1` in the latest LTS (13), so we need to adjust the bound accordingly to get the lib there (and in the nix packages).