### PR TITLE
Fix incorrect ToJSON instance for Bind

### DIFF
--- a/src/Docker/Client/Types.hs
+++ b/src/Docker/Client/Types.hs
@@ -944,7 +944,10 @@ instance ToJSON VolumeFrom where
 instance ToJSON Bind where
     toJSON (Bind src dest mode) = toJSON $ case mode of
                         Nothing -> T.concat[src, ":", dest]
-                        Just m ->  T.concat[src, ":", dest, ":", (T.pack $ show m)]
+                        Just m ->  T.concat[src, ":", dest, ":", str]
+                            where str = case m of 
+                                    ReadOnly -> "ro"
+                                    ReadWrite -> "rw"
 
 data Link = Link Text (Maybe Text) deriving (Eq, Show)
 

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -193,6 +193,19 @@ testVolumesJson = testGroup "Testing Volumes JSON" [testSample1, testSample2]
       HM.empty
     sampleVolumes = [Volume "/tmp", Volume "/opt"]
 
+testBindsJson :: TestTree
+testBindsJson = testGroup "Testing Binds JSON" [testSample1, testSample2, testSample3]
+  where
+    testSample1 =
+      testCase "Testing Bind without VolumePermission" $ 
+        JSON.String "/foo:/bar" @=? JSON.toJSON (Bind "/foo" "/bar" Nothing)
+    testSample2 =
+      testCase "Testing Bind with ReadOnly" $ 
+        JSON.String "/foo:/bar:ro" @=? JSON.toJSON (Bind "/foo" "/bar" (Just ReadOnly))
+    testSample3 =
+      testCase "Testing Bind with WriteOnly" $ 
+        JSON.String "/foo:/bar:rw" @=? JSON.toJSON (Bind "/foo" "/bar" (Just ReadWrite))
+
 testEntrypointJson :: TestTree
 testEntrypointJson = testGroup "Testing ContainerConfig JSON" [testSample1, testSample2, testSample3, testSample4, testSample5]
   where
@@ -257,6 +270,7 @@ jsonTests =
     "JSON Tests"
     [ testExposedPortsJson
     , testVolumesJson
+    , testBindsJson
     , testLabelsJson
     , testLogDriverOptionsJson
     , testEntrypointJson


### PR DESCRIPTION
There is a bug in the `ToJSON` instance for the `Bind` type which causes it to generate strings such as `"/host:/container:ReadWrite"` if a volume permission is specified rather than the expected `"/host:/container:rw"` or `"/host:/container:ro"`. This in turn leads to a HTTP 500 error from the Docker daemon if used.

This PR fixes this bug and adds test cases to check that the output is as expected. 

In terms of the fix, I am not super happy with the solution I ended up implementing. There are some other implementations I considered:

* Ideally, we'd use the existing `ToJSON` instance for `VolumePermission`, but `aeson` makes that awkward to use as a result from `encode` since that's a lazy `ByteString` and would have to be converted to a `Text` value. 
* Defining a `Show` instance for `VolumePermission` by hand which returns the required values would also work, but would not be backwards compatible (and a bit inconsistent with the other `Show` instances).
* Pattern-matching on the result of `toJSON m` to extract the `Text` value from that, but that would be partial  