### PR TITLE
Various improvements related to waitContainer

### DIFF
--- a/src/Docker/Client/Api.hs
+++ b/src/Docker/Client/Api.hs
@@ -121,6 +121,10 @@ stopContainer t cid = requestUnit POST $ StopContainerEndpoint t cid
 
 -- | Blocks until a container with the given 'ContainerID' stops,
 -- then returns the exit code
+-- 
+-- __NOTE__: this endpoint will not return a response until the container
+-- has stopped. This function may therefore fail with a timeout error if
+-- the timeout is configured incorrectly in the HTTP manager.
 waitContainer :: forall m. (MonadIO m, MonadMask m) => ContainerID -> DockerT m (Either DockerError ExitCode)
 waitContainer cid = fmap (fmap statusCodeToExitCode) (requestHelper POST (WaitContainerEndpoint cid) >>= parseResponse)
   where

--- a/src/Docker/Client/Http.hs
+++ b/src/Docker/Client/Http.hs
@@ -21,7 +21,8 @@ import           Data.X509.File               (readKeyFile, readSignedObject)
 import           Network.HTTP.Client          (defaultManagerSettings,
                                                managerRawConnection, method,
                                                newManager, parseRequest,
-                                               requestBody, requestHeaders)
+                                               requestBody, requestHeaders,
+                                               responseTimeout)
 import qualified Network.HTTP.Client          as HTTP
 import           Network.HTTP.Client.Internal (makeConnection)
 import qualified Network.HTTP.Simple          as NHS
@@ -46,7 +47,8 @@ import qualified Network.Socket.ByteString    as SBS
 
 import           Docker.Client.Internal       (getEndpoint,
                                                getEndpointContentType,
-                                               getEndpointRequestBody)
+                                               getEndpointRequestBody,
+                                               getEndpointTimeout)
 import           Docker.Client.Types          (DockerClientOpts, Endpoint (..),
                                                apiVer, baseUrl)
 
@@ -101,6 +103,7 @@ mkHttpRequest verb e opts = request
               request' = case  initialR of
                             Just ir ->
                                 return $ ir {method = (encodeUtf8 . T.pack $ show verb),
+                                              responseTimeout = getEndpointTimeout e,
                                               requestHeaders = [("Content-Type", (getEndpointContentType e))]}
                             Nothing -> Nothing
               request = (\r -> maybe r (\body -> r {requestBody = body,  -- This will either be a HTTP.RequestBodyLBS  or HTTP.RequestBodySourceChunked for the build endpoint

--- a/src/Docker/Client/Internal.hs
+++ b/src/Docker/Client/Internal.hs
@@ -106,3 +106,6 @@ getEndpointContentType :: Endpoint -> BSC.ByteString
 getEndpointContentType (BuildImageEndpoint _ _) = BSC.pack "application/tar"
 getEndpointContentType _ = BSC.pack "application/json; charset=utf-8"
 
+getEndpointTimeout :: Endpoint -> HTTP.ResponseTimeout 
+getEndpointTimeout (WaitContainerEndpoint _) = HTTP.responseTimeoutNone
+getEndpointTimeout _ = HTTP.responseTimeoutDefault

--- a/src/Docker/Client/Internal.hs
+++ b/src/Docker/Client/Internal.hs
@@ -106,6 +106,15 @@ getEndpointContentType :: Endpoint -> BSC.ByteString
 getEndpointContentType (BuildImageEndpoint _ _) = BSC.pack "application/tar"
 getEndpointContentType _ = BSC.pack "application/json; charset=utf-8"
 
-getEndpointTimeout :: Endpoint -> HTTP.ResponseTimeout 
+#if MIN_VERSION_http_client(0,5,0)
+getEndpointTimeout :: Endpoint -> HTTP.ResponseTimeout
 getEndpointTimeout (WaitContainerEndpoint _) = HTTP.responseTimeoutNone
 getEndpointTimeout _ = HTTP.responseTimeoutDefault
+#else
+-- Prior to version 0.5.0 of `http-client`, `ResponseTimeout` does not exist
+-- and we can't easily say "use the manager setting" here. So this is a bit
+-- ugly and only exists for the sake of backwards compatibility.
+getEndpointTimeout :: Endpoint -> Maybe Int
+getEndpointTimeout (WaitContainerEndpoint _) = Nothing
+getEndpointTimeout _ = Just 30000000
+#endif


### PR DESCRIPTION
This PR consists of three commits which address #78 in various ways:

* d3f961d212d640ce1203b90da7d93dcf94eee1ae simply documents the issue in `waitContainer`'s documentation
* b5cd7816656dc44fbfd18911a5f4c2b900f310e8 adds a new definition `defaultUnixManagerSettings`. This is just some code refactored out from `unixHttpHandler` so that `unixHttpHandler "/var/run/docker.sock"` is equivalent to:
```haskell
  let settings = defaultUnixManagerSettings "/var/run/docker.sock"
  manager <- newManager settings
  httpHandler manager
```
This allows the manager to be customised, e.g. to set a different timeout:
```haskell
  let settings = (defaultUnixManagerSettings "/var/run/docker.sock") {
    managerResponseTimeout = responseTimeoutNone
  }
  manager <- newManager settings
  httpHandler manager
```
* 015762aae3afbc0dd0a7a2d75a53dd51766f75ac is the most invasive commit and introduces a new function `getEndpointTimeout` which returns `responseTimeoutDefault` for all endpoints except `WaitContainerEndpoint` for which it returns `responseTimeoutNone`. This is then used in `mkHttpRequest` to set the value of `responseTimeout` for the request that is constructed.

I would think that the first two are fairly safe to merge, while the third one may require some thought.