### PR TITLE
Add support for pulling images from private registries

### DIFF
--- a/docker.cabal
+++ b/docker.cabal
@@ -26,6 +26,7 @@ library
   -- other-modules:       Docker.Internal
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.9.0 && < 2.0.0
+                     , base64-bytestring >= 1.0.0.0 && < 1.3.0.0
                      , blaze-builder >= 0.4.0 && < 0.5.0
                      , bytestring >= 0.10.0 && < 0.11.0
                      , containers >= 0.5.0 && < 0.7.0

--- a/src/Docker/Client/Api.hs
+++ b/src/Docker/Client/Api.hs
@@ -208,14 +208,11 @@ buildImageFromDockerfile opts base = do
 
 -- | Pulls an image from Docker Hub (by default).
 --
--- TODO: Add support for X-Registry-Auth and pulling from private docker
--- registries.
---
 -- TODO: Implement importImage function that uses he same
 -- CreateImageEndpoint but rather than pulling from docker hub it imports
 -- the image from a tarball or a URL.
-pullImage :: forall m b . (MonadIO m, MonadMask m) => T.Text -> Tag -> Sink BS.ByteString m b -> DockerT m (Either DockerError b)
-pullImage name tag = requestHelper' POST (CreateImageEndpoint name tag Nothing)
+pullImage :: forall m b . (MonadIO m, MonadMask m) => PullOpts -> T.Text -> Tag -> Sink BS.ByteString m b -> DockerT m (Either DockerError b)
+pullImage opts name tag = requestHelper' POST (CreateImageEndpoint name tag Nothing (pullAuthConfig opts))
 
 -- | Creates network
 createNetwork :: forall m. (MonadIO m, MonadMask m) => CreateNetworkOpts -> DockerT m (Either DockerError NetworkID)

--- a/src/Docker/Client/Http.hs
+++ b/src/Docker/Client/Http.hs
@@ -46,6 +46,7 @@ import qualified Network.Socket.ByteString    as SBS
 
 import           Docker.Client.Internal       (getEndpoint,
                                                getEndpointContentType,
+                                               getEndpointHeaders,
                                                getEndpointRequestBody)
 import           Docker.Client.Types          (DockerClientOpts, Endpoint (..),
                                                apiVer, baseUrl)
@@ -103,7 +104,8 @@ mkHttpRequest verb endpoint opts =
     -- Note: Do we need to set length header?
     setRequestFields request = request
       { method = HTTP.renderStdMethod verb
-      , requestHeaders = [("Content-Type", getEndpointContentType endpoint)]
+      , requestHeaders =
+          ("Content-Type", getEndpointContentType endpoint) : getEndpointHeaders endpoint
         -- This will either be a HTTP.RequestBodyLBS or
         -- HTTP.RequestBodySourceChunked for the build endpoint
       , requestBody =

--- a/src/Docker/Client/Http.hs
+++ b/src/Docker/Client/Http.hs
@@ -193,98 +193,29 @@ clientParamsSetCA params path = do
 
 -- If the status is an error, returns a Just DockerError. Otherwise, returns Nothing.
 statusCodeToError :: Endpoint -> HTTP.Status -> Maybe DockerError
-statusCodeToError VersionEndpoint st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (ListContainersEndpoint _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (ListImagesEndpoint _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (CreateContainerEndpoint _ _) st =
-    if st == status201 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (StartContainerEndpoint _ _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (StopContainerEndpoint _ _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (WaitContainerEndpoint _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (KillContainerEndpoint _ _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (RestartContainerEndpoint _ _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (PauseContainerEndpoint _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (UnpauseContainerEndpoint _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (ContainerLogsEndpoint _ _ _) st =
-    if st == status200 || st == status101 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (DeleteContainerEndpoint _ _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (InspectContainerEndpoint _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (BuildImageEndpoint _ _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (CreateImageEndpoint _ _ _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (DeleteImageEndpoint _ _) st =
-    if st == status200 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (CreateNetworkEndpoint _) st =
-    if st == status201 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
-statusCodeToError (RemoveNetworkEndpoint _) st =
-    if st == status204 then
-        Nothing
-    else
-        Just $ DockerInvalidStatusCode st
+statusCodeToError endpoint status
+  | status `elem` expectedStatuses
+  = Nothing
+  | otherwise
+  = Just $ DockerInvalidStatusCode status
+  where
+    expectedStatuses = case endpoint of
+      VersionEndpoint          {} -> [status200]
+      ListContainersEndpoint   {} -> [status200]
+      ListImagesEndpoint       {} -> [status200]
+      CreateContainerEndpoint  {} -> [status201]
+      StartContainerEndpoint   {} -> [status204]
+      StopContainerEndpoint    {} -> [status204]
+      WaitContainerEndpoint    {} -> [status200]
+      KillContainerEndpoint    {} -> [status204]
+      RestartContainerEndpoint {} -> [status204]
+      PauseContainerEndpoint   {} -> [status204]
+      UnpauseContainerEndpoint {} -> [status204]
+      ContainerLogsEndpoint    {} -> [status200, status101]
+      DeleteContainerEndpoint  {} -> [status204]
+      InspectContainerEndpoint {} -> [status200]
+      BuildImageEndpoint       {} -> [status200]
+      CreateImageEndpoint      {} -> [status200]
+      DeleteImageEndpoint      {} -> [status200]
+      CreateNetworkEndpoint    {} -> [status201]
+      RemoveNetworkEndpoint    {} -> [status204]


### PR DESCRIPTION
Fixes #82.

`pullImage` now takes a `PullOpts` argument, which includes an optional
`AuthConfig`. For more details, see:
https://docs.docker.com/engine/api/v1.41/#section/Authentication