### PR TITLE
Bump dependency version "http-client"

### DIFF
--- a/docker.cabal
+++ b/docker.cabal
@@ -30,7 +30,7 @@ library
                      , bytestring >= 0.10.0 && < 0.11.0
                      , containers >= 0.5.0 && < 0.7.0
                      , data-default-class >= 0.0.1 && < 0.2.0
-                     , http-client >= 0.4.0 && < 0.7.0
+                     , http-client >= 0.4.0 && < 0.8.0
                      , http-types >= 0.9 && < 0.13
                      , vector
                      , conduit


### PR DESCRIPTION
The "http-client" 0.7.x series of versions have been out for a while. I have confirmed that "docker-client" works well with `http-client 0.7.9`