### PR TITLE
Add Stack resolver for GHC 8.10.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        resolver: ["stack-7.10", "stack-8.0", "stack-8.0.2", "stack-8.6.4", "stack-8.8.2"]
+        resolver: ["stack-7.10", "stack-8.0", "stack-8.0.2", "stack-8.6.4", "stack-8.8.2", "stack-8.10.7"]
 
     runs-on: ubuntu-latest
 

--- a/docker.cabal
+++ b/docker.cabal
@@ -59,7 +59,7 @@ library
                      , x509-store >= 1.6.0 && < 1.8.0
                      , x509-system >= 1.6.0 && < 1.8.0
                      , http-conduit
-                     , unliftio-core >= 0.1.0.0 && < 0.2.0
+                     , unliftio-core >= 0.1.0.0 && < 0.3.0
   -- if flag(small-http-conduit)
   --     build-depends: http-conduit < 2.3.0
   -- else

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,0 +1,1 @@
+resolver: lts-18.27


### PR DESCRIPTION
This PR adds a Stack resolver for GHC 8.10.7 and raises the upper bound for `unliftio-core` to support it. It also adds the new resolver to the CI build matrix, so #87 should be merged first.