### PR TITLE
Support Aeson 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        resolver: ["stack-7.10", "stack-8.0", "stack-8.0.2", "stack-8.6.4", "stack-8.8.2", "stack-8.10.7"]
+        resolver:
+          - "stack-7.10"
+          - "stack-8.0"
+          - "stack-8.0.2"
+          - "stack-8.6.4"
+          - "stack-8.8.2"
+          - "stack-8.10.7"
+          - "stack-9.0.2"
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/stackage-nightly.yml
+++ b/.github/workflows/stackage-nightly.yml
@@ -1,0 +1,32 @@
+name: stackage-nightly
+
+on:
+  # allow this workflow to be run manually
+  workflow_dispatch:
+  schedule:
+    # run once a week on Monday mornings
+    - cron: "5 6 * * 1"
+  push:
+    # only run on push if this file changes
+    paths:
+      - ".github/workflows/stackage-nightly.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: haskell/actions/setup@v1
+        id: install-haskell
+        with:
+          enable-stack: true
+          stack-version: "latest"
+          stack-no-global: true
+          stack-setup-ghc: true
+
+      - name: Build and test with nightly snapshot
+        run: |
+          rm -f stack.yaml && stack init --resolver nightly
+          stack build --resolver nightly --haddock --test

--- a/docker.cabal
+++ b/docker.cabal
@@ -27,7 +27,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , aeson >= 0.9.0 && < 3.0.0
                      , blaze-builder >= 0.4.0 && < 0.5.0
-                     , bytestring >= 0.10.0 && < 0.11.0
+                     , bytestring >= 0.10.0 && < 0.12.0
                      , containers >= 0.5.0 && < 0.7.0
                      , data-default-class >= 0.0.1 && < 0.2.0
                      , http-client >= 0.4.0 && < 0.8.0

--- a/docker.cabal
+++ b/docker.cabal
@@ -25,7 +25,7 @@ library
   exposed-modules:     Docker.Client, Docker.Client.Api, Docker.Client.Types, Docker.Client.Internal, Docker.Client.Http, Docker.Client.Utils
   -- other-modules:       Docker.Internal
   build-depends:       base >= 4.7 && < 5
-                     , aeson >= 0.9.0 && < 2.0.0
+                     , aeson >= 0.9.0 && < 3.0.0
                      , blaze-builder >= 0.4.0 && < 0.5.0
                      , bytestring >= 0.10.0 && < 0.11.0
                      , containers >= 0.5.0 && < 0.7.0

--- a/docker.cabal
+++ b/docker.cabal
@@ -1,5 +1,5 @@
 name:                docker
-version:             0.6.0.6
+version:             0.7.0.0
 synopsis:            An API client for docker written in Haskell
 description:         See API documentation below.
 homepage:            https://github.com/denibertovic/docker-hs

--- a/src/Docker/Client/Http.hs
+++ b/src/Docker/Client/Http.hs
@@ -73,7 +73,7 @@ instance Applicative m => Applicative (DockerT m) where
     (<*>) (DockerT f) (DockerT v) =  DockerT $ f <*> v
 
 instance Monad m => Monad (DockerT m) where
-    (DockerT m) >>= f = DockerT $ m >>= unDockerT . f
+    (DockerT m) >>= f = DockerT $ m >>= \x -> unDockerT (f x)
     return = pure
 
 instance Monad m => MonadReader (DockerClientOpts, HttpHandler m) (DockerT m) where

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,0 +1,1 @@
+resolver: lts-19.0


### PR DESCRIPTION
This PR builds on #92 (so that should be merged first) and makes the following changes:

- `Docker.Client.Types` is updated to support `aeson >= 2` while still maintaining backwards compatibility with older versions
- A small change to `Docker.Client.Http` to support GHC 9
- Stack LTS-19 is the first to include GHC 9 and `aeson >= 2`, so I have added a configuration file for that and added it to the matrix build.
- A second GHA workflow `stackage-nightly` is added which builds the library using the latest `nightly` resolver.