### PR TITLE
Attempt to fix CI

### DIFF
--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -16,6 +16,8 @@ extra-deps:
 - unliftio-core-0.1.1.0
 - process-1.6.5.1
 
+allow-newer: true
+
 # Control whether we use the GHC we find on the path
 # system-ghc: true
 


### PR DESCRIPTION
Set `allow-newer: true` to fix CI for stack-7.10.yaml. This seems better to me than downgrading process.