### PR TITLE
Enable integration tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,4 +52,6 @@ jobs:
           stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal build --fast --test --no-run-tests
 
       - name: Test
-        run: stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test --fast
+        run: |
+          export RUN_INTEGRATION_TESTS=1
+          stack --stack-yaml=${{ matrix.resolver }}.yaml --no-terminal test --fast

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -51,7 +51,7 @@ runDocker f
           -- let settings = mkManagerSettings (TLSSettings params) Nothing
           -- mgr <- newManager settings
  = do
-  h <- defaultHttpHandler
+  h <- unixHttpHandler "/var/run/docker.sock"
   runDockerT (defaultClientOpts, h) f
 
 testDockerVersion :: IO ()


### PR DESCRIPTION
As mentioned by @jprider63 in https://github.com/denibertovic/docker-hs/pull/87#issuecomment-1073063780, I forgot to set `RUN_INTEGRATION_TESTS=1` to enable the integration tests in the new GHA-based CI. This PR enables the integration tests and also cherry-picks a commit from #79 to make it easier to connect to the Docker Unix socket, as [the tests fail if you try to connect to the Docker daemon via HTTP in the GHA workflow](https://github.com/denibertovic/docker-hs/actions/runs/2015054899).