### PR TITLE
Add compatibility with `lens-aeson-1.2`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles(format('{0}.yaml', matrix.resolver)) }}-
             ${{ runner.os }}-${{ matrix.resolver }}-
-            ${{ runner.os }}-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The tests depend on `lens-aeson` which has had [a major update](https://github.com/lens/lens-aeson/blob/master/CHANGELOG.markdown#12-20220319) in version 1.2, which is in the nightly Stack resolvers (forthcoming LTS 20 for GHC 9.2) to update its types in line with the changes in `aeson-2`. This PR modifies the tests to be compatible with this new version of `lens-aeson`. 

I have manually run the `stackage-nightly` workflow on my clone of the repository to check that it succeeds with the changes in this branch: https://github.com/mbg/docker-hs/actions/runs/2089799457. All the LTS workflows should pass as before.

I have also included a small change in the CI workflow configuration which ensures that the caches are kept separate between different Stack resolvers in order to remove a potential source of errors for the future.

See also https://github.com/denibertovic/docker-hs/pull/89#issuecomment-1086017860.